### PR TITLE
Fix version number in meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,15 @@
-{% set version = "v1.2.2" %}
+{% set version = "1.2.2" %}
 
 package:
   name: gmprocess
   version: {{ version }}
 
 source:
-  url: https://code.usgs.gov/ghsc/esi/groundmotion-processing/-/archive/{{ version }}/groundmotion-processing-v1.2.2.tar.gz
+  url: https://code.usgs.gov/ghsc/esi/groundmotion-processing/-/archive/v{{ version }}/groundmotion-processing-v{{ version }}.tar.gz
   sha256: c4aa8566f59a65e37b712bb48207f193d735aad065bcdd8c9ad5f2f270e88e67
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@ocefpaf I noticed that the version of the noarch build on https://anaconda.org/conda-forge/gmprocess is displayed as `vv1.2.2` and that the new build wasn't showing up when I run `conda search gmprocess`. So I think that setting the version with the "v" in font in meta.yaml was creating a problem. This is attempting to fix that. 
